### PR TITLE
only resolve address on start-up, reducing chance to fail

### DIFF
--- a/geo/geo.go
+++ b/geo/geo.go
@@ -19,13 +19,13 @@ import (
 	"github.com/codingsince1985/geo-golang"
 )
 
-func Get_coords(geocoder geo.Geocoder, city string) (float64, float64) {
-	location, _ := geocoder.Geocode(city)
-	if location == nil {
-		log.Fatalf("got <nil> location")
+func Get_coords(geocoder geo.Geocoder, city string) (float64, float64, error) {
+	location, err := geocoder.Geocode(city)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	log.Infof("Longitude: %f Latitude: %f for %s found, collecting metrics", location.Lng, location.Lat, city)
 
-	return location.Lat, location.Lng
+	return location.Lat, location.Lng, nil
 }


### PR DESCRIPTION
Hello! I had your exporter running but after only a couple hours it died like this

```
openweather-exporter[1283399]: time="2021-02-12T17:35:38+01:00" level=fatal msg="got <nil> location"
systemd[1]: openweather-exporter.service: Main process exited, code=exited, status=1/FAILURE
```

So this PR reworks the geolocation lookup to only happen once at startup, rather than during each collect- thus reducing risk of this failure.