### PR TITLE
Multiple locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Openweather exporter can be controlled by both ENV or CLI flags as described bel
 |----------------------------|-----------------------------|---------------------------- |------------------------------------------------------------------------------------------------------------------|
 | `OW_LISTEN_ADDRESS`           | `listen-address`            | `:9091`                     | The port for /metrics to listen on |
 | `OW_APIKEY`                   | `apikey`                    | `<REQUIRED>`                | Your Openweather API key |
-| `OW_CITY`                     | `city`                      | `New York, NY`              | City/Location in which to gather weather metrics |
+| `OW_CITY`                     | `city`                      | `New York, NY`              | City/Location in which to gather weather metrics. Separate multiple locations with \| |
 | `OW_DEGREES_UNIT`             | `degrees-unit`              | `F`                         | Unit in which to show metrics (Kelvin, Fahrenheit or Celsius) |
 | `OW_LANGUAGE`                 | `language`                  | `EN`                        | Language in which to show metrics |
 
@@ -67,7 +67,7 @@ scrape_configs:
 
 I have created a grafana dashboard for this exporter, feel free to use it. Link below.
 
-[Dashboard Link](https://github.com/billykwooten/GrafanaDashboards/blob/master/open_weather_map.json) 
+[Dashboard Link](https://github.com/billykwooten/GrafanaDashboards/blob/master/open_weather_map.json)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Openweather exporter can be controlled by both ENV or CLI flags as described bel
 |----------------------------|-----------------------------|---------------------------- |------------------------------------------------------------------------------------------------------------------|
 | `OW_LISTEN_ADDRESS`           | `listen-address`            | `:9091`                     | The port for /metrics to listen on |
 | `OW_APIKEY`                   | `apikey`                    | `<REQUIRED>`                | Your Openweather API key |
-| `OW_CITY`                     | `city`                      | `New York, NY`              | City/Location in which to gather weather metrics. Separate multiple locations with \| |
+| `OW_CITY`                     | `city`                      | `New York, NY`              | City/Location in which to gather weather metrics. Separate multiple locations with \| for example "New York, NY\|Seattle, WA" |
 | `OW_DEGREES_UNIT`             | `degrees-unit`              | `F`                         | Unit in which to show metrics (Kelvin, Fahrenheit or Celsius) |
 | `OW_LANGUAGE`                 | `language`                  | `EN`                        | Language in which to show metrics |
 

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -19,13 +19,13 @@ import (
 	"github.com/codingsince1985/geo-golang"
 )
 
-func Get_coords(geocoder geo.Geocoder, city string) (float64, float64) {
-	location, _ := geocoder.Geocode(city)
-	if location == nil {
-		log.Fatalf("got <nil> location")
+func Get_coords(geocoder geo.Geocoder, city string) (float64, float64, error) {
+	location, err := geocoder.Geocode(city)
+	if err != nil {
+		return 0, 0, err
 	}
 
 	log.Infof("Longitude: %f Latitude: %f for %s found, collecting metrics", location.Lng, location.Lat, city)
 
-	return location.Lat, location.Lng
+	return location.Lat, location.Lng, nil
 }

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -25,7 +25,7 @@ func Get_coords(geocoder geo.Geocoder, city string) (float64, float64, error) {
 		return 0, 0, err
 	}
 
-	log.Infof("Latitude: %f Longitude: %f for %s found, collecting metrics", location.Lat, location.Lng, city)
+	log.Infof("Latitude: %f Longitude: %f for %s found", location.Lat, location.Lng, city)
 
 	return location.Lat, location.Lng, nil
 }

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -25,7 +25,7 @@ func Get_coords(geocoder geo.Geocoder, city string) (float64, float64, error) {
 		return 0, 0, err
 	}
 
-	log.Infof("Longitude: %f Latitude: %f for %s found, collecting metrics", location.Lng, location.Lat, city)
+	log.Infof("Latitude: %f Longitude: %f for %s found, collecting metrics", location.Lat, location.Lng, city)
 
 	return location.Lat, location.Lng, nil
 }


### PR DESCRIPTION
Extend the exporter to allow collection of multiple locations. In order to keep compatibility, I extended the --city argument.

It is now possible to collect data from multiple locations like this: `--city "New York, NY|London, GB"`

This is based upon https://github.com/billykwooten/openweather-exporter/pull/14