### PR TITLE
Increase http client timeout

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -154,7 +154,7 @@ func (collector *OpenweatherCollector) Collect(ch chan<- prometheus.Metric) {
 
 		// Setup HTTP Client
 		client := &http.Client{
-			Timeout: 1 * time.Second,
+			Timeout: 30 * time.Second,
 		}
 
 		// Grab Metrics


### PR DESCRIPTION
Hello.
After having this exporter running for some days I notice it lacks data from time to time, which is due to "Client.Timeout exceeded while awaiting headers".

This PR should greatly improve upon the situation by increasing the http client timeout from 1 second to 30 seconds.