### PR TITLE
Call OpenWeatherMap OneCall 3.0 API directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor/
 
 # GoLand specific folders/files
 .idea/
+
+# VSCode Dev Containers configuration
+.devcontainer/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build Container Creation
 ########################
 
-FROM golang:1.19 as build
+FROM golang:1.21 as build
 
 ARG LD_FLAGS
 

--- a/collector/owm.go
+++ b/collector/owm.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Artem Tarasov
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+var (
+	DataUnits = map[string]string{"C": "metric", "F": "imperial", "K": "internal"}
+)
+
+func CurrentByCoordinates(loc Location, client *http.Client, settings *Settings) (*OneCallCurrentData, error) {
+	var onecall OneCallData
+
+	units, ok := DataUnits[settings.DegreesUnit]
+	if !ok {
+		return nil, fmt.Errorf("unknown unit %s (must be C, F, or K)", settings.DegreesUnit)
+	}
+
+	u, _ := url.Parse("https://api.openweathermap.org/data/3.0/onecall")
+
+	q := url.Values{}
+	q.Set("appid", settings.ApiKey)
+	q.Set("lat", fmt.Sprint(loc.Latitude))
+	q.Set("lon", fmt.Sprint(loc.Longitude))
+	q.Set("units", units)
+	q.Set("lang", settings.Language)
+	q.Set("excludes", "minutely,hourly,daily,alerts")
+
+	u.RawQuery = q.Encode()
+
+	response, err := client.Get(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+	if bytes, err := io.ReadAll(response.Body); err != nil {
+		return nil, err
+	} else if err := json.Unmarshal(bytes, &onecall); err != nil {
+		return nil, err
+	}
+
+	return &onecall.Current, nil
+}

--- a/collector/types.go
+++ b/collector/types.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Artem Tarasov
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// Documentation: https://openweathermap.org/api/one-call-3#current
+
+type Wind struct {
+	Speed float64 `json:"speed"`
+	Deg   float64 `json:"deg"`
+}
+
+type Rain struct {
+	OneH float64 `json:"1h,omitempty"`
+}
+
+type Snow struct {
+	OneH float64 `json:"1h,omitempty"`
+}
+
+// https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
+type Weather struct {
+	ID          int    `json:"id"`
+	Main        string `json:"main"`
+	Description string `json:"description"`
+	Icon        string `json:"icon"`
+}
+
+// the API should be called with exclude=minutely,hourly,daily,alerts
+type OneCallData struct {
+	Latitude       float64            `json:"lat"`
+	Longitude      float64            `json:"lon"`
+	Timezone       string             `json:"timezone"`
+	TimezoneOffset int                `json:"timezone_offset"`
+	Current        OneCallCurrentData `json:"current,omitempty"`
+}
+
+type OneCallCurrentData struct {
+	Dt         int       `json:"dt"`
+	Sunrise    int       `json:"sunrise"`
+	Sunset     int       `json:"sunset"`
+	Temp       float64   `json:"temp"`
+	FeelsLike  float64   `json:"feels_like"`
+	Pressure   int       `json:"pressure"`
+	Humidity   int       `json:"humidity"`
+	DewPoint   float64   `json:"dew_point"`
+	Clouds     int       `json:"clouds"`
+	UVI        float64   `json:"uvi"`
+	Visibility int       `json:"visibility"`
+	WindSpeed  float64   `json:"wind_speed"`
+	WindGust   float64   `json:"wind_gust,omitempty"`
+	WindDeg    float64   `json:"wind_deg"`
+	Rain       Rain      `json:"rain,omitempty"`
+	Snow       Snow      `json:"snow,omitempty"`
+	Weather    []Weather `json:"weather"`
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/billykwooten/openweather-exporter
 
-go 1.19
+go 1.21
 
 require (
-	github.com/briandowns/openweathermap v0.19.0
 	github.com/codingsince1985/geo-golang v1.8.3
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/briandowns/openweathermap v0.19.0 h1:nkopLMEtZLxbZI1th6dOG6xkajpszofqf53r5K8mT9k=
-github.com/briandowns/openweathermap v0.19.0/go.mod h1:0GLnknqicWxXnGi1IqoOaZIw+kIe5hkt+YM5WY3j8+0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/codingsince1985/geo-golang v1.8.3 h1:73TRG/poj1IUiYOoaEM7gD/+ZBSRg+BPnWoGpAg+NHc=

--- a/main.go
+++ b/main.go
@@ -71,7 +71,10 @@ func main() {
 		log.Info("Ultraviolet Index metrics enabled, this will call the API more than once per call.")
 	}
 
-	weatherCollector := collector.NewOpenweatherCollector(*degreesUnit, *language, *apiKey, *city, cache, *enablePol, *enableUV)
+	settings := collector.Settings{
+		DegreesUnit: *degreesUnit, Language: *language, ApiKey: *apiKey,
+	}
+	weatherCollector := collector.NewOpenweatherCollector(&settings, *city, cache)
 	prometheus.MustRegister(weatherCollector)
 
 	// This section will start the HTTP server and expose


### PR DESCRIPTION
This addresses https://github.com/billykwooten/openweather-exporter/issues/39

I removed the dependency on the owm library and simply copied a few struct definitions from there.

 - [x] UV index is available straight from OneCall 3.0, there's no need for a separate API call
 - [ ] According to the docs, Pollution API should continue to work; I propose to add another function to collector/owm.go instead of relying on the library