### PR TITLE
feat(chart): add ability to reference secret

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for OpenWeather Exporter
 
 type: application
 
-version: 0.1.0
+version: 0.2.0
 
 appVersion: 0.0.13

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -24,7 +24,16 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-{{ .Chart.Name }}-cm
             - secretRef:
+            {{- if and .Values.ow.apiKey .Values.ow.secretRef}}
+              {{- fail "cannot set both .ow.apiKey and .ow.secretRef"}}
+            {{- else if and (empty .Values.ow.apiKey) (empty .Values.ow.secretRef) }}
+              {{- fail "you need to set either .ow.apiKey or .ow.apiKey" }}
+            {{- end}}
+            {{- if and .Values.ow.secretRef (not .Values.ow.apiRef) }}
+                name: {{ .Values.ow.secretRef }}
+            {{- else }}
                 name: {{ .Release.Name }}-{{ .Chart.Name }}-secret
+            {{- end }}
           env:
             {{- range .Values.env_vars }}
             - name: {{ .name }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ow.apiKey }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,3 +9,4 @@ metadata:
     app: {{ .Release.Name }}-{{ .Chart.Name }}
 stringData:
   OW_APIKEY: {{ .Values.ow.apiKey }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,15 +27,19 @@ serviceMonitor:
   # serviceMonitor.scrapeTimeout -- Timeout after which the scrape is ended
   scrapeTimeout: 30s
   # serviceMonitor.serviceMonitorSelector -- Selector for Service Monitor to be picked up by Prometheus Operator
-  serviceMonitorSelector: {
+  serviceMonitorSelector:
     release: prometheus
-  }
 
 ow:
   # ow.port -- Port to expose /metrics on, used both in pod and for service
   port: "9091"
+
+  # either set the apiKey here or reference and existing secret with an OW_APIKEY key
   # ow.apiKey -- Your Openweather API key
   apiKey: ""
+  # ow.secretRef -- a ref to en existing secret
+  secretRef: ""
+
   # ow.city -- City/Location in which to gather weather metrics. Separate multiple locations with | for example "New York, NY|Seattle, WA"
   city: "New York, NY"
   # ow.degreesUnit -- Unit in which to show metrics (Kelvin, Fahrenheit or Celsius)


### PR DESCRIPTION
The PR introduces the ability to either set the `apiKey` directly in the values file or reference an existing secret. This helps in situation in which e.g. sops encryption for secrets is used. That is very common with flux.