### PR TITLE
collector: check err on client.Get

### DIFF
--- a/collector/owm.go
+++ b/collector/owm.go
@@ -16,10 +16,11 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"net/url"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -60,6 +61,9 @@ func CurrentByCoordinates(loc Location, client *http.Client, settings *Settings)
 
 	log.Infof("Gathering Metrics from Openweather API 3.0 for %s, Lat:%f, Lon:%f", loc.Location, loc.Latitude, loc.Longitude)
 	response, err := client.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
 
 	// Success is indicated with 2xx status codes:
 	statusOK := response.StatusCode >= 200 && response.StatusCode < 300


### PR DESCRIPTION
This fixes this panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x8613a5]

goroutine 15647 [running]:
github.com/billykwooten/openweather-exporter/collector.CurrentByCoordinates({{0x821a8bd00?, 0x9?}, 0x404a1602c0a4a05e?, 0x401402bd3c361134?}, 0x86c13e720, 0x86c212140)
        /home/dvaneeden/dev/openweather-exporter/collector/owm.go:65 +0x725
github.com/billykwooten/openweather-exporter/collector.(*OpenweatherCollector).collectOneCall.func1()
        /home/dvaneeden/dev/openweather-exporter/collector/collector.go:146 +0x30
github.com/billykwooten/openweather-exporter/collector.cachedHttpRequest[...](0x86c4a8140, {0x86c220270, 0x11}, 0x86c778680)
        /home/dvaneeden/dev/openweather-exporter/collector/collector.go:131 +0xa9
github.com/billykwooten/openweather-exporter/collector.(*OpenweatherCollector).collectOneCall(0x86c4a8140, {{0x821a8bd00?, 0x86c1821c0?}, 0x86c042a08?, 0x86c778748?}, 0x86c182000)
        /home/dvaneeden/dev/openweather-exporter/collector/collector.go:144 +0xc7
github.com/billykwooten/openweather-exporter/collector.(*OpenweatherCollector).Collect(0x86c4a8140, 0x86c182000)
        /home/dvaneeden/dev/openweather-exporter/collector/collector.go:117 +0x85
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /home/dvaneeden/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/registry.go:455 +0x105
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 185
        /home/dvaneeden/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/registry.go:547 +0xbf1
```

This happens if `client.Get()` failed and `response` is set to `nil` and we then try to check `response.StatusCode`...