### PR TITLE
metrics: add visibility and weather condition id

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ scrape_configs:
 
 Openweather exporter metrics that are collected by default.
 
-| Name        	                   | Description                                                                  |
+| Name        	                  | Description                                                                  |
 |---------------------------------|------------------------------------------------------------------------------|
 | `openweather_temperature`       | `Current temperature in degrees`                                             |
 | `openweather_humidity`          | `Current relative humidity`                                                  |
@@ -94,11 +94,12 @@ Openweather exporter metrics that are collected by default.
 | `openweather_sunrise`           | `Sunrise time, unix, UTC`                                                    |
 | `openweather_sunset`            | `Sunset time, unix, UTC`                                                     |
 | `openweather_currentconditions` | `Current weather conditions (sunny, cloudy, rainy, etc.)`                    |
-| `openweather_ultraviolet_index` | `Ultraviolet Index` |
+| `openweather_ultraviolet_index` | `Ultraviolet Index`                                                          |
+| `openweather_visibility`        | `Visibility in meters`                                                       |
 
 If you enable pollution metrics, the following metrics will be enabled.
 
-| Name        	                            | Description                                                                     |
+| Name        	                           | Description                                                                     |
 |------------------------------------------|---------------------------------------------------------------------------------|
 | `openweather_pollution_airqualityindex`  | `Air Quality Index. 1 = Good, 2 = Fair, 3 = Moderate, 4 = Poor, 5 = Very Poor.` |
 | `openweather_pollution_carbonmonoxide`   | `Concentration of CO (Carbon Monoxide) μg/m3`                                   |

--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -92,12 +92,21 @@ func OneCallGauges(location string) []Metric {
 		makeGauge("openweather_ultraviolet_index", "Ultraviolet Index",
 			func(d *OneCallCurrentData) float64 { return d.UVI },
 		),
+		makeGauge("openweather_visibility", "Visibility in meters",
+			func(d *OneCallCurrentData) float64 { return float64(d.Visibility) },
+		),
 		&Gauge[*OneCallCurrentData]{
 			prometheus.NewDesc("openweather_currentconditions",
 				"Current weather conditions",
 				[]string{"location", "currentconditions"}, nil,
 			),
-			func(*OneCallCurrentData) float64 { return 0 },
+			func(d *OneCallCurrentData) float64 {
+				var weatherID float64
+				for _, n := range d.Weather {
+					weatherID = float64(n.ID)
+				}
+				return weatherID
+			},
 			func(d *OneCallCurrentData) []string {
 				// Get Weather description out of Weather slice to pass as label
 				var weatherDescription string


### PR DESCRIPTION
Add:
- `current.visibility` as `openweather_visibility`
- `current.weather.id` as value for `openweather_currentconditions` instead of `0` (the description is in the label)