### PR TITLE
feat: Add `icon` label to `openweather_currentconditions`

### DIFF
--- a/collector/metrics.go
+++ b/collector/metrics.go
@@ -95,16 +95,18 @@ func OneCallGauges(location string) []Metric {
 		&Gauge[*OneCallCurrentData]{
 			prometheus.NewDesc("openweather_currentconditions",
 				"Current weather conditions",
-				[]string{"location", "currentconditions"}, nil,
+				[]string{"location", "currentconditions", "icon"}, nil,
 			),
 			func(*OneCallCurrentData) float64 { return 0 },
 			func(d *OneCallCurrentData) []string {
 				// Get Weather description out of Weather slice to pass as label
 				var weatherDescription string
+				var icon string
 				for _, n := range d.Weather {
 					weatherDescription = n.Description
+					icon = n.Icon
 				}
-				return []string{location, weatherDescription}
+				return []string{location, weatherDescription, icon}
 			},
 		},
 	}


### PR DESCRIPTION
Thank you for providing such an excellent Exporter.  
I would like to request the addition of one feature.  

## Description  
- Added `icon` as a label for `currentconditions`.  

## Motivation and Context

- The [One API 3.0](https://openweathermap.org/api/one-call-3#parameter) includes a parameter called `current.weather.icon`, which represents an ID from OpenWeather's predefined icon set. You can find the full list [here](https://openweathermap.org/weather-conditions#How-to-get-icon-URL).  
- By enabling this in the Exporter as a `currentconditions` label, users will be able to display current weather conditions using an icon in Grafana through an image-output plugin such as the [Dynamic image panel](https://grafana.com/grafana/plugins/dalvany-image-panel/).  

## How Has This Been Tested?  
- I have built and tested the implementation to confirm that the expected data is correctly retrieved.
  ```
  # TYPE openweather_currentconditions gauge
  openweather_currentconditions{currentconditions="clear sky",icon="01d",location="Kashiwa, JP"} 0
  ```
- I verified its functionality in Grafana and confirmed that it works as expected using the Dynamic image panel plugin.  
  <img width="1233" src="https://github.com/user-attachments/assets/9f080f5b-079e-446a-a78c-c3f942dca5f5" />

## Appendix  
- [One Call API 3.0 - OpenWeatherMap](https://openweathermap.org/api/one-call-3)  
- [Weather Conditions - OpenWeatherMap](https://openweathermap.org/weather-conditions)  
- [Dynamic image panel plugin for Grafana | Grafana Labs](https://grafana.com/grafana/plugins/dalvany-image-panel/)  
